### PR TITLE
get accurate retval from ssh commands

### DIFF
--- a/lib/bootstrapper/config_generators/chef_client.rb
+++ b/lib/bootstrapper/config_generators/chef_client.rb
@@ -198,10 +198,10 @@ chef_server_url '#{options.chef_server_url}'
         ui.msg("Creating Chef config directory /etc/chef")
         # TODO: don't hardcode sudo
         ssh_session.pty_run(ssh_session.sudo(<<-SCRIPT), true)
-  mkdir -p -m 0700 /etc/chef;  \
-  chown root /etc/chef;        \
-  chgrp root /etc/chef;        \
-  chmod 0755 /etc/chef
+  mkdir -p -m 0700 /etc/chef || exit 1;  \
+  chown root /etc/chef || exit 1;        \
+  chgrp root /etc/chef;                  \
+  chmod 0755 /etc/chef || exit 1
   SCRIPT
         files_to_install.each do |file|
           # TODO: support paths outside /etc/chef?
@@ -210,10 +210,10 @@ chef_server_url '#{options.chef_server_url}'
 
           # TODO: don't hardcode sudo
           ssh_session.pty_run(ssh_session.sudo(<<-SCRIPT), true)
-  mv #{temp_path(file.rel_path)} #{final_path};   \
-  chown root #{final_path};                       \
-  chgrp root #{final_path};                       \
-  chmod #{file.mode} #{final_path}
+  mv #{temp_path(file.rel_path)} #{final_path} || exit 1;   \
+  chown root #{final_path} || exit 1;                       \
+  chgrp root #{final_path};                                 \
+  chmod #{file.mode} #{final_path} || exit 1
   SCRIPT
         end
       end

--- a/spec/bootstrapper/config_generators/chef_client_spec.rb
+++ b/spec/bootstrapper/config_generators/chef_client_spec.rb
@@ -218,20 +218,20 @@ describe Bootstrapper::ConfigGenerators::ChefClient do
       config_generator.stage_files(transport)
 
       create_chef_dir=<<-EOH
-  mkdir -p -m 0700 /etc/chef;  \
-  chown root /etc/chef;        \
-  chgrp root /etc/chef;        \
-  chmod 0755 /etc/chef
+  mkdir -p -m 0700 /etc/chef || exit 1;  \
+  chown root /etc/chef || exit 1;        \
+  chgrp root /etc/chef;                  \
+  chmod 0755 /etc/chef || exit 1
 EOH
 
       transport.should_receive(:sudo).with(create_chef_dir).and_return("sudo #{create_chef_dir}")
       transport.should_receive(:pty_run).with("sudo #{create_chef_dir}", true)
 
       move_staged_file=<<-EOH
-  mv #{staging_dir}/test.sh /etc/chef/test.sh;   \
-  chown root /etc/chef/test.sh;                       \
-  chgrp root /etc/chef/test.sh;                       \
-  chmod 0600 /etc/chef/test.sh
+  mv #{staging_dir}/test.sh /etc/chef/test.sh || exit 1;   \
+  chown root /etc/chef/test.sh || exit 1;                       \
+  chgrp root /etc/chef/test.sh;                                 \
+  chmod 0600 /etc/chef/test.sh || exit 1
 EOH
 
       sudo_move_staged_file = "sudo #{move_staged_file}"


### PR DESCRIPTION
- throw an 'exception' if any of the critical ssh commands fail
- this is complicated by chgrp root possibly failing if the root
  group does not exist and is instead wheel -- which we ignore
- feels like this is going down the wrong rabbit hole, i'd prefer
  to just chain the commands with && and drop the explict chown and
  chgrp entirely.
